### PR TITLE
Avoid double counting in delete

### DIFF
--- a/FibonacciHeap.java
+++ b/FibonacciHeap.java
@@ -188,15 +188,13 @@ public class FibonacciHeap
 	 * Return the number of links.
 	 *
 	 */
-	public int delete(HeapNode x) 
-	{    
-		int cuts = this.decreaseKey(x, Integer.MAX_VALUE); //ensure x will be the new min
-		int links = this.deleteMin();
-		this.linksCount += links; //update total links count 
-		this.cutsCount += cuts; //update total cuts count 
+        public int delete(HeapNode x)
+        {
+                this.decreaseKey(x, Integer.MAX_VALUE); //ensure x will be the new min
+                int links = this.deleteMin();
 
-		return links;
-	}
+                return links;
+        }
 
 
 	/**


### PR DESCRIPTION
## Summary
- remove redundant counter updates from `delete`
- rely on `decreaseKey` and `deleteMin` for statistics

## Testing
- `javac FibonacciHeap.java testers/FibonacciHeapTester.java`
- `java -cp .:testers FibonacciHeapTester`


------
https://chatgpt.com/codex/tasks/task_e_6853cc8e41d48329ad8da475a9df7fbc